### PR TITLE
fix: graph/heap/Dijkstra correctness, test-runner migration, interop 0.7.0

### DIFF
--- a/.dropecho.testing.json
+++ b/.dropecho.testing.json
@@ -1,0 +1,9 @@
+{
+  "root_package": "dropecho.ds",
+  "instrument": {
+    "coverage": true,
+    "profiler": false,
+    "coverage_reporter": "coverage-lcov-reporter"
+  },
+  "hxml": "test.hxml"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ report
 .temp
 coverage
 dist
+.nyc_output
+lcov.info
+*.swp
+.vim/

--- a/.munit
+++ b/.munit
@@ -1,6 +1,0 @@
-version=2.3.5
-src=test
-bin=artifacts
-report=artifacts/reports
-hxml=test.hxml
-classPaths=src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,21 @@
 Single source of truth for all AI agents working on this project.
 See `.agents/` for deeper reference docs.
 
+## Agent Instructions
+
+- **Always use the `haxe` skill** when reading or writing any `.hx` or `.hxml` file.
+- **Always use the Haxe LSP** (`LSP` tool) for navigating code — go-to-definition, find
+  references, hover types — before grepping or reading files manually.
+- **Never co-author or co-sign commits — no exceptions.** Commit messages must contain
+  **zero** attribution, authorship, or sign-off trailers. This explicitly forbids
+  `Co-Authored-By`, `Signed-off-by`, `Co-developed-by`, `Reviewed-by`, `Acked-by`,
+  `Tested-by`, `Generated-by`, or any `*-by:` line, as well as "Generated with"/tool-credit
+  footers and any agent or AI attribution. This applies to every commit, amend, rebase, and
+  squash, regardless of any default or tool-provided template. If a template or upstream
+  message contains such a trailer, strip it before committing.
+- **Never add section/region divider comments** (e.g. `// ── Foo ──`, `// --- Foo ---`,
+  `#region`). Organize code with ordering and doc comments instead.
+
 ---
 
 ## Project Overview
@@ -13,7 +28,7 @@ of data structures and algorithms targeted at games. It compiles to JS (ESM + CJ
 - **Version:** 1.8.0
 - **License:** MIT
 - **Targets:** JS (Node.js, browser), C# (.NET 4.0)
-- **Test runner:** `haxelib run dropecho.testing` (wraps utest)
+- **Test runner:** `lix dropecho.testing` (wraps utest)
 - **Source root:** `src/`  · **Tests root:** `test/`
 
 ---

--- a/haxe_libraries/dropecho.interop.hxml
+++ b/haxe_libraries/dropecho.interop.hxml
@@ -1,3 +1,3 @@
-# @install: lix --silent download "haxelib:/dropecho.interop#0.6.0" into dropecho.interop/0.6.0/haxelib
--cp ${HAXE_LIBCACHE}/dropecho.interop/0.6.0/haxelib/src/
--D dropecho.interop=0.6.0
+# @install: lix --silent download "haxelib:/dropecho.interop#0.7.0" into dropecho.interop/0.7.0/haxelib
+-cp ${HAXE_LIBCACHE}/dropecho.interop/0.7.0/haxelib/src/
+-D dropecho.interop=0.7.0

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   },
   "license": "MIT",
   "scripts": {
-    "install": "lix download",
+    "prepare": "lix download",
     "build": "npm run build:code",
     "build:code": "haxe build.hxml",
     "build:docs": "haxelib run dox -o docs/docs -i artifacts/docs.xml --toplevel-package dropecho.ds",
-    "test": "haxelib run dropecho.testing"
+    "test": "lix dropecho.testing",
+    "clean": "rm -rf dist artifacts"
   },
   "type": "module",
   "main": "./dist/js/cjs/index.cjs",

--- a/src/dropecho/ds/Graph.hx
+++ b/src/dropecho/ds/Graph.hx
@@ -82,13 +82,12 @@ class Graph<T, U> implements IGraph<T, U> {
 			return [];
 		}
 
-		var labels = [
-			for (label => data in edges.get(node.label)) {
-				if (filter == null || filter(label, data)) {
-					label;
-				}
+		var labels = [];
+		for (label => data in edges.get(node.label)) {
+			if (filter == null || filter(label, data)) {
+				labels.push(label);
 			}
-		];
+		}
 
 		haxe.ds.ArraySort.sort(labels, Reflect.compare);
 		return labels;

--- a/src/dropecho/ds/Heap.hx
+++ b/src/dropecho/ds/Heap.hx
@@ -73,11 +73,16 @@ class Heap<T> {
 	 * @return The (min/max)imum element on the heap.
 	 */
 	public function pop():T {
-		var element = elements.shift();
-		if (elements.length > 1) {
+		if (elements.length == 0) {
+			return null;
+		}
+		var top = elements[0];
+		var last = elements.pop();
+		if (elements.length > 0) {
+			elements[0] = last;
 			_rebuild(0);
 		}
-		return element;
+		return top;
 	}
 
 	/**
@@ -109,10 +114,10 @@ class Heap<T> {
 		var right = _getRightIndex(index);
 		var top = index;
 
-		if (left < length && compare(els[left], els[index])) {
+		if (left < length && compare(els[left], els[top])) {
 			top = left;
 		}
-		if (right < length && compare(els[right], els[index])) {
+		if (right < length && compare(els[right], els[top])) {
 			top = right;
 		}
 

--- a/src/dropecho/ds/RingBuffer.hx
+++ b/src/dropecho/ds/RingBuffer.hx
@@ -13,6 +13,7 @@ class RingBuffer<T> {
 	public var length(get, never):Int;
 
 	public function new(capacity:Int, overwrite:Bool = true) {
+		if (capacity < 1) throw "RingBuffer capacity must be >= 1";
 		this.capacity = capacity;
 		_overwrite = overwrite;
 		_data = [];

--- a/src/dropecho/ds/SpatialHash.hx
+++ b/src/dropecho/ds/SpatialHash.hx
@@ -10,6 +10,7 @@ class SpatialHash<T> {
 	public var cellSize(default, null):Float;
 
 	public function new(cellSize:Float) {
+		if (cellSize <= 0) throw "SpatialHash cellSize must be > 0";
 		this.cellSize = cellSize;
 		_cells = new AbstractMap<String, Array<T>>();
 	}

--- a/src/dropecho/ds/graph/Search.hx
+++ b/src/dropecho/ds/graph/Search.hx
@@ -16,11 +16,9 @@ class NodeDist<T, U> {
 }
 
 @:struct
-class SearchResult {
-	/** Node label -> previous node label on the shortest path (null for the source). */
-	public var path:AbstractMap<String, String>;
-	/** Node label -> shortest distance from the source. */
-	public var distances:AbstractMap<String, Float>;
+class SearchResult<T, U> {
+	public var path:AbstractMap<IGraphNode<T, U>, String>;
+	public var distances:AbstractMap<IGraphNode<T, U>, Float>;
 
 	public function new(path, distances) {
 		this.path = path;
@@ -48,29 +46,24 @@ class Search {
 	 * @param node      The source node.
 	 * @param distCalc  Optional edge-weight function; defaults to 1.0 per hop.
 	 */
-	public static function dijkstra<T, U>(node:IGraphNode<T, U>, ?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float):SearchResult {
+	public static function dijkstra<T, U>(node:IGraphNode<T, U>, ?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float):SearchResult<T, U> {
 		var compare = (a, b) -> (Reflect.compare(a.dist, b.dist) < 0);
 		var queue = new Heap<NodeDist<T, U>>(compare);
-		// Keyed by node label, not the node object: an object-keyed AbstractMap is a
-		// @:multiType abstract that only reliably resolves to an ObjectMap in some
-		// builds — under coverage instrumentation it degrades to Std.string(node)
-		// string keys, which collide and corrupt the search. Labels are unique and
-		// always resolve to a StringMap.
-		var dist = new AbstractMap<String, Float>();
-		var prev = new AbstractMap<String, String>();
+		var dist = new AbstractMap<IGraphNode<T, U>, Float>();
+		var prev = new AbstractMap<IGraphNode<T, U>, String>();
 
 		var graph = node.graph;
 
 		distCalc = distCalc != null ? distCalc : (a, b) -> 1.0;
 
-		dist[node.label] = 0.0;
+		dist[node] = 0.0;
 
 		for (n in graph.nodes) {
 			if (n != node) {
-				dist[n.label] = Math.POSITIVE_INFINITY;
-				prev[n.label] = null;
+				dist[n] = Math.POSITIVE_INFINITY;
+				prev[n] = null;
 			}
-			queue.push(new NodeDist(n, dist[n.label]));
+			queue.push(new NodeDist(n, dist[n]));
 		}
 
 		while (queue.size() > 0) {
@@ -80,12 +73,12 @@ class Search {
 			var neighbors = graph.neighbors(minDistNode, filter);
 
 			for (neighbor in neighbors) {
-				var distanceToNeighbor = dist[minDistNode.label] + distCalc(minDistNode, neighbor);
-				if (distanceToNeighbor <= dist[neighbor.label]) {
-					dist[neighbor.label] = distanceToNeighbor;
-					prev[neighbor.label] = minDistNode.label;
+				var distanceToNeighbor = dist[minDistNode] + distCalc(minDistNode, neighbor);
+				if (distanceToNeighbor <= dist[neighbor]) {
+					dist[neighbor] = distanceToNeighbor;
+					prev[neighbor] = minDistNode.label;
 					var existing = queue.elements.find(x -> x.node == neighbor);
-					queue.replace(existing, new NodeDist(neighbor, dist[neighbor.label]));
+					queue.replace(existing, new NodeDist(neighbor, dist[neighbor]));
 				}
 			}
 		}

--- a/src/dropecho/ds/graph/Search.hx
+++ b/src/dropecho/ds/graph/Search.hx
@@ -16,9 +16,11 @@ class NodeDist<T, U> {
 }
 
 @:struct
-class SearchResult<T, U> {
-	public var path:AbstractMap<IGraphNode<T, U>, String>;
-	public var distances:AbstractMap<IGraphNode<T, U>, Float>;
+class SearchResult {
+	/** Node label -> previous node label on the shortest path (null for the source). */
+	public var path:AbstractMap<String, String>;
+	/** Node label -> shortest distance from the source. */
+	public var distances:AbstractMap<String, Float>;
 
 	public function new(path, distances) {
 		this.path = path;
@@ -46,24 +48,29 @@ class Search {
 	 * @param node      The source node.
 	 * @param distCalc  Optional edge-weight function; defaults to 1.0 per hop.
 	 */
-	public static function dijkstra<T, U>(node:IGraphNode<T, U>, ?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float):SearchResult<T, U> {
+	public static function dijkstra<T, U>(node:IGraphNode<T, U>, ?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float):SearchResult {
 		var compare = (a, b) -> (Reflect.compare(a.dist, b.dist) < 0);
 		var queue = new Heap<NodeDist<T, U>>(compare);
-		var dist = new AbstractMap<IGraphNode<T, U>, Float>();
-		var prev = new AbstractMap<IGraphNode<T, U>, String>();
+		// Keyed by node label, not the node object: an object-keyed AbstractMap is a
+		// @:multiType abstract that only reliably resolves to an ObjectMap in some
+		// builds — under coverage instrumentation it degrades to Std.string(node)
+		// string keys, which collide and corrupt the search. Labels are unique and
+		// always resolve to a StringMap.
+		var dist = new AbstractMap<String, Float>();
+		var prev = new AbstractMap<String, String>();
 
 		var graph = node.graph;
 
 		distCalc = distCalc != null ? distCalc : (a, b) -> 1.0;
 
-		dist[node] = 0.0;
+		dist[node.label] = 0.0;
 
 		for (n in graph.nodes) {
 			if (n != node) {
-				dist[n] = Math.POSITIVE_INFINITY;
-				prev[n] = null;
+				dist[n.label] = Math.POSITIVE_INFINITY;
+				prev[n.label] = null;
 			}
-			queue.push(new NodeDist(n, dist[n]));
+			queue.push(new NodeDist(n, dist[n.label]));
 		}
 
 		while (queue.size() > 0) {
@@ -73,12 +80,12 @@ class Search {
 			var neighbors = graph.neighbors(minDistNode, filter);
 
 			for (neighbor in neighbors) {
-				var distanceToNeighbor = dist[minDistNode] + distCalc(minDistNode, neighbor);
-				if (distanceToNeighbor <= dist[neighbor]) {
-					dist[neighbor] = distanceToNeighbor;
-					prev[neighbor] = minDistNode.label;
+				var distanceToNeighbor = dist[minDistNode.label] + distCalc(minDistNode, neighbor);
+				if (distanceToNeighbor <= dist[neighbor.label]) {
+					dist[neighbor.label] = distanceToNeighbor;
+					prev[neighbor.label] = minDistNode.label;
 					var existing = queue.elements.find(x -> x.node == neighbor);
-					queue.replace(existing, new NodeDist(neighbor, dist[neighbor]));
+					queue.replace(existing, new NodeDist(neighbor, dist[neighbor.label]));
 				}
 			}
 		}

--- a/src/dropecho/ds/graph/Search.hx
+++ b/src/dropecho/ds/graph/Search.hx
@@ -89,7 +89,10 @@ class Search {
 	 * A* shortest path from start to end.
 	 * @param start      The source node.
 	 * @param end        The target node.
-	 * @param heuristic  Estimated cost from a node to end. Must be admissible (never overestimates).
+	 * @param heuristic  Estimated cost from a node to end. Must be admissible (never
+	 *                   overestimates). Inconsistent (non-monotone) admissible heuristics
+	 *                   are still optimal here because closed nodes are reopened when a
+	 *                   cheaper path is found.
 	 * @param distCalc   Optional edge-weight function; defaults to 1.0 per hop.
 	 * @return AStarResult with the ordered path array and a found flag.
 	 */
@@ -138,12 +141,15 @@ class Search {
 			}
 
 			for (neighbor in graph.outNeighbors(current)) {
-				if (closed.exists(neighbor.label)) continue;
 				var tentativeG = gScore[current] + distCalc(current, neighbor);
 				var neighborG = gScore[neighbor];
 				if (tentativeG < neighborG) {
 					gScore[neighbor] = tentativeG;
 					prev[neighbor] = current.label;
+					// A cheaper path to neighbor was found. If it was already closed,
+					// reopen it so the improvement can propagate — this keeps A* optimal
+					// even when the heuristic is admissible but not consistent.
+					if (closed.exists(neighbor.label)) closed.remove(neighbor.label);
 					openSet.push(new NodeDist(neighbor, tentativeG + heuristic(neighbor, end)));
 				}
 			}

--- a/src/dropecho/ds/graph/Search.hx
+++ b/src/dropecho/ds/graph/Search.hx
@@ -4,9 +4,14 @@ import dropecho.interop.AbstractMap;
 
 using Lambda;
 
+/** A node paired with a tentative distance, used as the priority-queue element
+    for the searches below. The heap orders these by `dist`. */
 @:struct
 class NodeDist<T, U> {
+	/** The graph node this entry refers to. */
 	public var node:IGraphNode<T, U>;
+
+	/** The priority key: tentative distance (Dijkstra) or f-score (A*). Lower pops first. */
 	public var dist:Float;
 
 	public function new(node, dist) {
@@ -15,9 +20,15 @@ class NodeDist<T, U> {
 	}
 }
 
+/** The result of a Dijkstra search from a single source. */
 @:struct
 class SearchResult<T, U> {
+	/** Predecessor map: each node -> the previous node's label on its shortest
+	    path back to the source. The source maps to null. Walk this backwards to
+	    reconstruct a path. */
 	public var path:AbstractMap<IGraphNode<T, U>, String>;
+
+	/** Each node -> its shortest distance from the source (POSITIVE_INFINITY if unreachable). */
 	public var distances:AbstractMap<IGraphNode<T, U>, Float>;
 
 	public function new(path, distances) {
@@ -26,10 +37,13 @@ class SearchResult<T, U> {
 	}
 }
 
+/** The result of an A* search between two nodes. */
 @:struct
 class AStarResult<T, U> {
-	/** Ordered path from start to end, or null if no path exists. */
+	/** The ordered path from start to end inclusive, or null if no path exists. */
 	public var path:Array<IGraphNode<T, U>>;
+
+	/** Whether a path from start to end was found. */
 	public var found:Bool;
 
 	public function new(path, found) {
@@ -45,8 +59,10 @@ class Search {
 	 * Dijkstra shortest-path from a source node to all reachable nodes.
 	 * @param node      The source node.
 	 * @param distCalc  Optional edge-weight function; defaults to 1.0 per hop.
+	 * @return A SearchResult mapping every node to its shortest distance and predecessor.
 	 */
 	public static function dijkstra<T, U>(node:IGraphNode<T, U>, ?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float):SearchResult<T, U> {
+		// Min-heap: the smallest tentative distance is always popped next.
 		var compare = (a, b) -> (Reflect.compare(a.dist, b.dist) < 0);
 		var queue = new Heap<NodeDist<T, U>>(compare);
 		var dist = new AbstractMap<IGraphNode<T, U>, Float>();
@@ -56,6 +72,7 @@ class Search {
 
 		distCalc = distCalc != null ? distCalc : (a, b) -> 1.0;
 
+		// Source sits at distance 0; every other node starts unreachable.
 		dist[node] = 0.0;
 
 		for (n in graph.nodes) {
@@ -68,6 +85,8 @@ class Search {
 
 		while (queue.size() > 0) {
 			var minDistNode = queue.pop().node;
+			// Once popped, a node is finalized. Restrict relaxation to neighbors still
+			// in the queue so we never re-open a node whose distance is already settled.
 			var existingLabels = queue.elements.map(x -> x.node.label);
 			var filter = (label, data) -> existingLabels.indexOf(label) >= 0;
 			var neighbors = graph.neighbors(minDistNode, filter);
@@ -77,6 +96,7 @@ class Search {
 				if (distanceToNeighbor <= dist[neighbor]) {
 					dist[neighbor] = distanceToNeighbor;
 					prev[neighbor] = minDistNode.label;
+					// Update the neighbor's queue entry in place with its new, lower priority.
 					var existing = queue.elements.find(x -> x.node == neighbor);
 					queue.replace(existing, new NodeDist(neighbor, dist[neighbor]));
 				}
@@ -96,17 +116,15 @@ class Search {
 	 * @param distCalc   Optional edge-weight function; defaults to 1.0 per hop.
 	 * @return AStarResult with the ordered path array and a found flag.
 	 */
-	public static function astar<T, U>(
-		start:IGraphNode<T, U>,
-		end:IGraphNode<T, U>,
-		heuristic:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float,
-		?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float
-	):AStarResult<T, U> {
+	public static function astar<T, U>(start:IGraphNode<T, U>, end:IGraphNode<T, U>, heuristic:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float,
+			?distCalc:(a:IGraphNode<T, U>, b:IGraphNode<T, U>) -> Float):AStarResult<T, U> {
 		distCalc = distCalc != null ? distCalc : (a, b) -> 1.0;
 
 		var graph = start.graph;
+		// gScore[n] = best known cost from start to n; prev[n] = predecessor's label.
 		var gScore = new AbstractMap<IGraphNode<T, U>, Float>();
 		var prev = new AbstractMap<IGraphNode<T, U>, String>();
+		// Labels of nodes whose shortest path is settled (popped from the open set).
 		var closed = new AbstractMap<String, Bool>();
 
 		for (n in graph.nodes) {
@@ -115,24 +133,31 @@ class Search {
 		}
 		gScore[start] = 0.0;
 
+		// Open set ordered by f-score (g + heuristic); the most promising node pops first.
 		var openSet = new Heap<NodeDist<T, U>>((a, b) -> (Reflect.compare(a.dist, b.dist) < 0));
 		openSet.push(new NodeDist(start, heuristic(start, end)));
 
 		while (openSet.size() > 0) {
 			var current = openSet.pop().node;
 
-			if (closed.exists(current.label)) continue;
+			// A node can sit in the open set more than once; skip stale duplicates.
+			if (closed.exists(current.label))
+				continue;
 			closed.set(current.label, true);
 
 			if (current == end) {
+				// Walk predecessors back from end to start, then reverse into start->end order.
 				var path:Array<IGraphNode<T, U>> = [];
 				var node = end;
 				while (node != start) {
 					path.push(node);
-					if (!prev.exists(node)) break;
+					if (!prev.exists(node))
+						break;
 					var label = prev[node];
-					if (label == null) break;
-					if (!node.graph.nodes.exists(label)) break;
+					if (label == null)
+						break;
+					if (!node.graph.nodes.exists(label))
+						break;
 					node = node.graph.nodes.get(label);
 				}
 				path.push(start);
@@ -149,7 +174,8 @@ class Search {
 					// A cheaper path to neighbor was found. If it was already closed,
 					// reopen it so the improvement can propagate — this keeps A* optimal
 					// even when the heuristic is admissible but not consistent.
-					if (closed.exists(neighbor.label)) closed.remove(neighbor.label);
+					if (closed.exists(neighbor.label))
+						closed.remove(neighbor.label);
 					openSet.push(new NodeDist(neighbor, tentativeG + heuristic(neighbor, end)));
 				}
 			}

--- a/src/dropecho/ds/graph/Traversal.hx
+++ b/src/dropecho/ds/graph/Traversal.hx
@@ -95,60 +95,60 @@ class Traversal {
 }
 
 class TarjanState<T, U> {
-	var graph:IGraph<T, U>;
-	var disc:AbstractMap<String, Int>;
-	var low:AbstractMap<String, Int>;
-	var onStack:AbstractMap<String, Bool>;
-	var stack:Array<String>;
-	var components:Array<Array<IGraphNode<T, U>>>;
-	var timer:Int;
+	var _graph:IGraph<T, U>;
+	var _disc:AbstractMap<String, Int>;
+	var _low:AbstractMap<String, Int>;
+	var _onStack:AbstractMap<String, Bool>;
+	var _stack:Array<String>;
+	var _components:Array<Array<IGraphNode<T, U>>>;
+	var _timer:Int;
 
 	public function new(graph:IGraph<T, U>) {
-		this.graph = graph;
-		disc = new AbstractMap<String, Int>();
-		low = new AbstractMap<String, Int>();
-		onStack = new AbstractMap<String, Bool>();
-		stack = [];
-		components = [];
-		timer = 0;
+		_graph = graph;
+		_disc = new AbstractMap<String, Int>();
+		_low = new AbstractMap<String, Int>();
+		_onStack = new AbstractMap<String, Bool>();
+		_stack = [];
+		_components = [];
+		_timer = 0;
 	}
 
 	public function run():Array<Array<IGraphNode<T, U>>> {
-		for (node in graph.nodes) {
-			if (!disc.exists(node.label)) dfs(node);
+		for (node in _graph.nodes) {
+			if (!_disc.exists(node.label)) dfs(node);
 		}
-		return components;
+		return _components;
 	}
 
 	function dfs(node:IGraphNode<T, U>):Void {
-		disc.set(node.label, timer);
-		low.set(node.label, timer);
-		timer++;
-		stack.push(node.label);
-		onStack.set(node.label, true);
+		_disc.set(node.label, _timer);
+		_low.set(node.label, _timer);
+		_timer++;
+		_stack.push(node.label);
+		_onStack.set(node.label, true);
 
-		for (neighbor in graph.outNeighbors(node)) {
-			if (!disc.exists(neighbor.label)) {
+		for (neighbor in _graph.outNeighbors(node)) {
+			if (!_disc.exists(neighbor.label)) {
 				dfs(neighbor);
-				var neighborLow = low.get(neighbor.label);
-				var nodeLow = low.get(node.label);
-				if (neighborLow < nodeLow) low.set(node.label, neighborLow);
-			} else if (onStack.exists(neighbor.label) && onStack.get(neighbor.label)) {
-				var neighborDisc = disc.get(neighbor.label);
-				var nodeLow = low.get(node.label);
-				if (neighborDisc < nodeLow) low.set(node.label, neighborDisc);
+				var neighborLow = _low.get(neighbor.label);
+				var nodeLow = _low.get(node.label);
+				if (neighborLow < nodeLow) _low.set(node.label, neighborLow);
+			} else if (_onStack.exists(neighbor.label) && _onStack.get(neighbor.label)) {
+				var neighborDisc = _disc.get(neighbor.label);
+				var nodeLow = _low.get(node.label);
+				if (neighborDisc < nodeLow) _low.set(node.label, neighborDisc);
 			}
 		}
 
-		if (low.get(node.label) == disc.get(node.label)) {
+		if (_low.get(node.label) == _disc.get(node.label)) {
 			var scc:Array<IGraphNode<T, U>> = [];
 			while (true) {
-				var label = stack.pop();
-				onStack.set(label, false);
-				scc.push(graph.nodes.get(label));
+				var label = _stack.pop();
+				_onStack.set(label, false);
+				scc.push(_graph.nodes.get(label));
 				if (label == node.label) break;
 			}
-			components.push(scc);
+			_components.push(scc);
 		}
 	}
 }

--- a/src/dropecho/ds/graph/Traversal.hx
+++ b/src/dropecho/ds/graph/Traversal.hx
@@ -11,7 +11,11 @@ class Traversal {
 	 */
 	public static function topologicalSort<T, U>(graph:IGraph<T, U>):Array<IGraphNode<T, U>> {
 		var inDegree = new AbstractMap<String, Int>();
-		for (node in graph.nodes) inDegree.set(node.label, 0);
+		var nodeCount = 0;
+		for (node in graph.nodes) {
+			inDegree.set(node.label, 0);
+			nodeCount++;
+		}
 
 		for (fromLabel => nodeEdges in graph.edges) {
 			for (toLabel => _ in nodeEdges) {
@@ -39,8 +43,6 @@ class Traversal {
 			}
 		}
 
-		var nodeCount = 0;
-		for (_ in graph.nodes) nodeCount++;
 		return sorted.length == nodeCount ? sorted : null;
 	}
 

--- a/test/graph/DijkstraTests.hx
+++ b/test/graph/DijkstraTests.hx
@@ -42,12 +42,12 @@ class DijkstraTests extends Test {
 		var results = Search.dijkstra(node1);
 		var path = results.path;
 
-		Assert.isFalse(path.exists(node1.label));
-		Assert.equals(node1.label, path[node4.label]);
-		Assert.equals(node1.label, path[node2.label]);
-		Assert.equals(node4.label, path[node6.label]);
-		Assert.equals(node2.label, path[node3.label]);
-		Assert.equals(node2.label, path[node5.label]);
+		Assert.isFalse(path.exists(node1));
+		Assert.equals(node1.label, path[node4]);
+		Assert.equals(node1.label, path[node2]);
+		Assert.equals(node4.label, path[node6]);
+		Assert.equals(node2.label, path[node3]);
+		Assert.equals(node2.label, path[node5]);
 	}
 
 	function test_weighted_edges() {
@@ -79,14 +79,14 @@ class DijkstraTests extends Test {
 		var dist = results.distances;
 		var path = results.path;
 
-		Assert.equals(0.0, dist[nodeA.label]);
-		Assert.equals(2.0, dist[nodeC.label]);
-		Assert.equals(4.0, dist[nodeD.label]);
+		Assert.equals(0.0, dist[nodeA]);
+		Assert.equals(2.0, dist[nodeC]);
+		Assert.equals(4.0, dist[nodeD]);
 		// B is cheaper via C->D->B (cost 6) than directly (cost 10).
-		Assert.equals(6.0, dist[nodeB.label]);
+		Assert.equals(6.0, dist[nodeB]);
 
 		// Verify the actual path taken to B goes through D, not directly from A.
-		Assert.equals(nodeD.label, path[nodeB.label]);
+		Assert.equals(nodeD.label, path[nodeB]);
 	}
 
 	function test_traversal() {
@@ -137,12 +137,12 @@ class DijkstraTests extends Test {
 		var results = Search.dijkstra(node1);
 		var dist = results.distances;
 
-		Assert.equals(0, dist[node1.label]);
-		Assert.equals(1, dist[node2.label]);
-		Assert.equals(2, dist[node3.label]);
-		Assert.equals(1, dist[node4.label]);
-		Assert.equals(2, dist[node5.label]);
-		Assert.equals(3, dist[node6.label]);
-		Assert.equals(2, dist[node7.label]);
+		Assert.equals(0, dist[node1]);
+		Assert.equals(1, dist[node2]);
+		Assert.equals(2, dist[node3]);
+		Assert.equals(1, dist[node4]);
+		Assert.equals(2, dist[node5]);
+		Assert.equals(3, dist[node6]);
+		Assert.equals(2, dist[node7]);
 	}
 }

--- a/test/graph/DijkstraTests.hx
+++ b/test/graph/DijkstraTests.hx
@@ -42,12 +42,12 @@ class DijkstraTests extends Test {
 		var results = Search.dijkstra(node1);
 		var path = results.path;
 
-		Assert.isFalse(path.exists(node1));
-		Assert.equals(node1.label, path[node4]);
-		Assert.equals(node1.label, path[node2]);
-		Assert.equals(node4.label, path[node6]);
-		Assert.equals(node2.label, path[node3]);
-		Assert.equals(node2.label, path[node5]);
+		Assert.isFalse(path.exists(node1.label));
+		Assert.equals(node1.label, path[node4.label]);
+		Assert.equals(node1.label, path[node2.label]);
+		Assert.equals(node4.label, path[node6.label]);
+		Assert.equals(node2.label, path[node3.label]);
+		Assert.equals(node2.label, path[node5.label]);
 	}
 
 	function test_weighted_edges() {
@@ -79,14 +79,14 @@ class DijkstraTests extends Test {
 		var dist = results.distances;
 		var path = results.path;
 
-		Assert.equals(0.0, dist[nodeA]);
-		Assert.equals(2.0, dist[nodeC]);
-		Assert.equals(4.0, dist[nodeD]);
+		Assert.equals(0.0, dist[nodeA.label]);
+		Assert.equals(2.0, dist[nodeC.label]);
+		Assert.equals(4.0, dist[nodeD.label]);
 		// B is cheaper via C->D->B (cost 6) than directly (cost 10).
-		Assert.equals(6.0, dist[nodeB]);
+		Assert.equals(6.0, dist[nodeB.label]);
 
 		// Verify the actual path taken to B goes through D, not directly from A.
-		Assert.equals(nodeD.label, path[nodeB]);
+		Assert.equals(nodeD.label, path[nodeB.label]);
 	}
 
 	function test_traversal() {
@@ -137,12 +137,12 @@ class DijkstraTests extends Test {
 		var results = Search.dijkstra(node1);
 		var dist = results.distances;
 
-		Assert.equals(0, dist[node1]);
-		Assert.equals(1, dist[node2]);
-		Assert.equals(2, dist[node3]);
-		Assert.equals(1, dist[node4]);
-		Assert.equals(2, dist[node5]);
-		Assert.equals(3, dist[node6]);
-		Assert.equals(2, dist[node7]);
+		Assert.equals(0, dist[node1.label]);
+		Assert.equals(1, dist[node2.label]);
+		Assert.equals(2, dist[node3.label]);
+		Assert.equals(1, dist[node4.label]);
+		Assert.equals(2, dist[node5.label]);
+		Assert.equals(3, dist[node6.label]);
+		Assert.equals(2, dist[node7.label]);
 	}
 }

--- a/test/graph/TraversalTests.hx
+++ b/test/graph/TraversalTests.hx
@@ -12,8 +12,6 @@ class TraversalTests extends Test {
 		graph = new Graph<Int, Int>();
 	}
 
-	// ── Topological Sort ──────────────────────────────────────────────────────
-
 	public function test_topological_sort_on_dag() {
 		// A -> B -> C, A -> C
 		var a = graph.createNode(1, "A");
@@ -67,8 +65,6 @@ class TraversalTests extends Test {
 		Assert.equals(a, sorted[0]);
 	}
 
-	// ── Cycle Detection ───────────────────────────────────────────────────────
-
 	public function test_hasCycle_false_on_dag() {
 		var a = graph.createNode(1, "A");
 		var b = graph.createNode(2, "B");
@@ -88,8 +84,6 @@ class TraversalTests extends Test {
 		graph.createNode(1, "A");
 		Assert.isFalse(Traversal.hasCycle(graph));
 	}
-
-	// ── Connected Components ──────────────────────────────────────────────────
 
 	public function test_connected_components_single_component() {
 		var a = graph.createNode(1, "A");
@@ -127,8 +121,6 @@ class TraversalTests extends Test {
 		var comps = Traversal.connectedComponents(graph);
 		Assert.equals(3, comps.length);
 	}
-
-	// ── Strongly Connected Components ─────────────────────────────────────────
 
 	public function test_scc_dag_each_node_is_own_scc() {
 		var a = graph.createNode(1, "A");


### PR DESCRIPTION
## Summary

Addresses the findings from a code review of the recent data-structures work, fixes the pre-existing Dijkstra failure (which turned out to be three independent bugs), refreshes docs, and updates tooling.

## Correctness fixes
- **Graph:** `outNeighborLabels` pushed the value of an `if`-without-`else` from its array comprehension, so every filter-rejected edge appended `null` to the label list. `nodes.get(null)` then crashed on C# (`ArgumentNullException`) and silently corrupted on JS. This was the root cause of the Dijkstra crash — its filter rejects already-closed neighbors on every iteration.
- **Heap:** `_rebuild` compared the right child against `els[index]` instead of the running best (`els[top]`), so it could sift the *larger* child up and violate the heap property; `pop()` used `shift()`, which renumbers the array and destroys parent/child index relationships. Both replaced with a correct sift-down and swap-last-to-root pop. Existing HeapTests passed only because their sequences never triggered the bad-child case.
- **A\*:** reopen closed nodes when a cheaper path is found, keeping A\* optimal for admissible-but-inconsistent heuristics.
- **RingBuffer:** reject `capacity < 1` to avoid modulo-by-zero.
- **SpatialHash:** reject `cellSize <= 0` to avoid division-by-zero.

## Cleanup / docs
- Document the `Search` structs (`NodeDist`, `SearchResult`, `AStarResult`) with field-level comments, and annotate the non-obvious steps of `dijkstra`/`astar`.
- `topologicalSort`: count nodes during the in-degree build instead of a second pass.
- `TarjanState`: underscore-prefix private fields per conventions.
- Remove section-divider comments in `TraversalTests`.

## Tooling
- Migrate the test runner to `lix dropecho.testing` (utest + coverage instrumentation) and add agent docs.
- Bump `dropecho.interop` to `0.7.0` (restructured `AbstractMap`, adds `ObjectKeyedMap`).

## Note on history
`ef75be4` (key Dijkstra maps by label) was a workaround later proven unnecessary once the Graph/Heap bugs were fixed, and is reverted by `f72fe2d`. Net-zero on the source; can squash on request.

## Testing
- `haxe build.hxml` (JS + C#) — passes
- `lix dropecho.testing` (instrumented, JS + C#) — passes, zero errors/assertion failures